### PR TITLE
Add default folder and let iTerm windows open if no path present

### DIFF
--- a/macterminal_iterm.scpt
+++ b/macterminal_iterm.scpt
@@ -1,18 +1,24 @@
 on run argv
-    set folderName to item 1 of argv -- Folder path
-    
+    -- Don't set if no path to use
+    if count of argv is 1 then
+        set folderName to item 1 of argv -- Folder path
+    end if
+
     tell application "iTerm"
         activate
+
         make new terminal
-        
+
         tell the first terminal
             launch session "Default Session"
             set _session to current session
         end tell
         
-        tell _session
-            write text "cd \"" & folderName & "\""
-            write text "clear"
-        end tell
+        if folderName is not missing value then
+            tell _session
+                write text "cd \"" & folderName & "\""
+                write text "clear"
+            end tell
+        end if
     end tell
 end run

--- a/open_mac_terminal.py
+++ b/open_mac_terminal.py
@@ -24,6 +24,7 @@ class OpenMacTerminal(sublime_plugin.TextCommand):#pylint: disable-msg=R0903,W02
         #get settings
         settings = sublime.load_settings('MacTerminal.sublime-settings')
         terminal_name = settings.get("terminal")
+        default_path = settings.get("default-path")
         if len(terminal_name) == 0:
             return
 
@@ -45,7 +46,11 @@ class OpenMacTerminal(sublime_plugin.TextCommand):#pylint: disable-msg=R0903,W02
         elif self.view.window().active_view().file_name() is not None:
             command.append(os.path.dirname(self.view.window().active_view().file_name()))#pylint: disable-msg=E1101
         else:
-            print "This may be a bug, please create issue on github"
+            if len(default_path) > 0:
+                exp_path = os.path.normpath(os.path.expanduser(default_path))
+                command.append(exp_path)
+            else:
+                print "This may be a bug, please create issue on github"
 
         print command
 


### PR DESCRIPTION
In iTerm if you try to open a terminal when there's no path present,
it'll break.  This just checks to see if a path is present to cd to
after opening the terminal.  Also added a default-path setting for when
the above situation occurs
