### PR TITLE
fix bug in iterm2 applescript

### DIFF
--- a/macterminal_iterm.scpt
+++ b/macterminal_iterm.scpt
@@ -7,9 +7,9 @@ on run argv
     tell application "iTerm"
         activate
 
-        make new terminal
+        set _term to (make new terminal)
 
-        tell the first terminal
+        tell _term
             launch session "Default Session"
             set _session to current session
         end tell


### PR DESCRIPTION
Sometimes with a terminal already open, the original script would
create a new terminal but call cd in the already existing terminal.
This commit fixes this issue by referring to the newly created terminal
explicitly.
