### PR TITLE
Update packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7,12 +7,11 @@
             "author": "Rafał 'afterdesign' Malinowski",
             "homepage": "https://github.com/afterdesign/MacTerminal",
             "labels": ["terminal"],
-            "readme": "https://raw.github.com/afterdesign/MacTerminal/master/README.md",
             "releases" : [
                 {
+                    "sublime_text": "*",
                     "platforms": ["osx", "osx-x64"],
-                    "details": "https://github.com/afterdesign/MacTerminal/tags",
-                    "date": "2013-11-28 20:49:00"
+                    "details": "https://github.com/afterdesign/MacTerminal/tags"
                 }
             ]
         }


### PR DESCRIPTION
We require sublime_text version selectors now due to the confusion it caused in the past

Also removed date key because it was overridden by details anyway
