### PR TITLE
Fixes behavior of no action when configured with directory_mode = project and sublime has not a project open

### DIFF
--- a/open_mac_terminal.py
+++ b/open_mac_terminal.py
@@ -37,7 +37,8 @@ class OpenMacTerminal(sublime_plugin.TextCommand):#pylint: disable-msg=R0903,W02
 
         if directory_mode == "project":
             path = self.get_first_project_directory()
-        else:
+        
+        if directory_mode != "project" or path == None:
             path = self.get_current_path(paths)
 
         run_command(path)


### PR DESCRIPTION
Hi, thanks for the project.

I was having this problem when opening ST for a single file editing. When hitting the shortcut no action was performed.

Changed this piece of the code to make it work for me.
