### PR TITLE
Open at project as a command argument + some other tweaks

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,13 @@
 [
   {
-    "caption": "Open in Terminal",
+    "caption": "Open Terminal Here",
     "command": "open_termx_terminal"
+  },
+  {
+    "caption": "Open Terminal at Project",
+    "command": "open_termx_terminal",
+    "args" : {
+        "project": true
+    }
   }
 ]

--- a/README.md
+++ b/README.md
@@ -1,117 +1,49 @@
-# Sublime Text terminal plugin for macs
+# Sublime Text terminal plugin for macOS
 
-1. Fully packaged
-2. Currently with option to open new tab
-3. Sublime Text 2 and 3
+Fully packaged and able to open in a new tab.
 
-# Installation
-### From git:
-```
-cd $PATH_OF_SUBLIME_PACKAGES
-git clone git://github.com/afterdesign/termX.git
-```
-
-### From [package control](http://wbond.net/sublime_packages/package_control)
-Just type termX
+Install via [Package Control](http://wbond.net/sublime_packages/package_control), or clone the repo into your packages directory.
 
 
-# Keybinding
-
-Default keybinding is:
+## Keybinding
+Default keybinding is `ctrl+cmd+t`. To change it go to:
 
 ```
-ctrl+cmd+t
+Sublime Text -> Preferences -> Package Settings -> termX -> Key Bindings
 ```
 
-To change it go to:
+
+## Settings
+To change settings go to:
 
 ```
-Sublime Text 2 -> Preferences -> Package Settings -> termX -> Key Bindings
+Sublime Text -> Preferences -> Package Settings -> termX -> Settings
 ```
 
-And set something similar to:
+The available options will be explained in the left hand panel.
 
-```json
-{ "keys": ["ctrl+super+t"], "command": "open_termx_terminal" }
-```
 
-# Alternative terminals:
+### Alternative terminals:
 
-By default this plugin is using native ```Terminal.app```.
+By default this plugin uses the native `Terminal.app`.
 You can also use [iTerm2](http://iterm2.com) and (thanks to awesome [@JohnBehnke](https://github.com/JohnBehnke)) [Hyper](http://hyper.is).
 
-To change settings edit:
 
-```
-Sublime Text 2 -> Preferences -> Package Settings -> termX -> Settings - User
-```
+### Terminal opening strategy
 
-And change terminal setting to ```iterm``` (default is ```terminal```):
+By default termX opens a new terminal in directory of the current file. You can change this to open in the current directory.
 
-```json
-{
-    "terminal"   :  "terminal/iterm/hyper"
-}
-```
 
-# Terminal opening strategy
-
-By default termX is opening terminal with path to directory where currently edited file is placed.
-
-You can change this behavious by editing settings file:
-
-```
-Sublime Text 2 -> Preferences -> Package Settings -> termX -> Settings - User
-```
-
-Default option is ```file``` and you can change it to ```project```:
-
-```json
-{
-    "directory_mode" : "file/project"
-}
-```
-
-# FAQ
+## FAQ
 
 1. The "Open in terminal" is greyed out.
     This happens when there is no opened file and for now I don't know if
     this is just a sublime bug or I need to change something.
-        For now I saw the same behavior in
+ 
 
+2. Can I always open main directory of project ?
 
-2. How do I change path to ``` osascript ``` ?
-
-    To check what is path for ``` osascript ``` just open terminal and type:
-
-    ```
-    which osascript
-    ```
-
-    With path simply go to:
-
-    ```
-    Sublime Text 2 -> Preferences -> Package Settings -> termX -> Settings - User
-    ```
-
-    and add:
-
-    ```
-    {
-        "osascript"   :  "/usr/bin/osascript"
-    }
-    ```
-
-3. Can I always open main directory of project ?
-
-    From version 2.0 you can.
-
-    Open:
-    ```
-    Sublime Text 2 -> Preferences -> Package Settings -> termX -> Settings - User
-    ```
-
-    And set :
+    Edit the settings and change `directory_mode` to `project`:
     ```
     {
         "directory_mode" : "project"
@@ -125,22 +57,22 @@ Default option is ```file``` and you can change it to ```project```:
 
     Thanks [@dirajkumar](https://github.com/dirajkumar) for the idea !
 
-4. Its not working for me.
+3. Its not working for me.
 
-    First of all enable ```debug``` mode. To do this open your settings and add:
-    ``` "debug": true ```
+    First of all enable `debug` mode. 
+    To do this open your settings and add: `"debug": true`
 
-    After this try to open terminal again. If it's not working (and debug shouldn't repair the problem)
-    open sublime console (default shortcut is ``` ctrl+` ```) and open new issue with log
+    After this try to open terminal again. If it's not working
+    open the Sublime Text console and open new issue with the log
     between ```---termX Debug Start---``` and ```---termX Debug End---```.
 
     You can always ping me on [twitter](http://twitter.com/afterdeign) or
     simply write [issue on github](https://github.com/afterdesign/termX/issues).
 
-# Contact
+## Contact
 
 All info about me you can find on my "goto page": [http://malinowski.be](https://malinowski.be) or just ping me on twitter: [@afterdesign](http://twitter.com/afterdesign)
 
-# License
+## License
 
 Licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -39,25 +39,8 @@ By default termX opens a new terminal in directory of the current file. You can 
 1. The "Open in terminal" is greyed out.
     This happens when there is no opened file and for now I don't know if
     this is just a sublime bug or I need to change something.
- 
 
-2. Can I always open main directory of project ?
-
-    Edit the settings and change `directory_mode` to `project`:
-    ```
-    {
-        "directory_mode" : "project"
-    }
-    ```
-
-    From now on if you have only 1 directory added to project it's going to be opened by default.
-    If you have more than 1 directory in your project you'll see quickpanel to select what you would like to open.
-
-    ![](https://raw.github.com/afterdesign/termX/master/messages/termx_2.gif)
-
-    Thanks [@dirajkumar](https://github.com/dirajkumar) for the idea !
-
-3. Its not working for me.
+2. Its not working for me.
 
     First of all enable `debug` mode. 
     To do this open your settings and add: `"debug": true`

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -1,11 +1,10 @@
 [
     {"caption":"-", "id":"side-bar-terminal-separator"},
     {
-        "caption": "Open in Terminal",
-        "id": "side-bar-new-terminal",
+        "caption": "Open Terminal Here",
         "command": "open_termx_terminal",
         "args" : {
-            "paths" : []
+            "paths": []
         }
     }
 ]

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -86,8 +86,7 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         elif len(self.paths) > 1:
             self.window.show_quick_panel(
                 self.paths,
-                self.open_selected_direcotory,
-                sublime.MONOSPACE_FONT
+                self.open_selected_direcotory
             )
 
     def open_selected_direcotory(self, selected_index):

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -97,27 +97,16 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
 
     def open_terminal(self):
         '''
-        Choose what to open - terminal with current path or quick selection window
+        Open a terminal with current path or quick selection window
         '''
-        if len(self.paths) == 0:
-            return False
-
         if len(self.paths) == 1:
             self.open_terminal_command(self.paths[0])
-            return True
-
-        self.show_directory_selection()
-
-    def show_directory_selection(self):
-        '''
-        Open quick selection window with paths
-        '''
-
-        self.window.show_quick_panel(  # pylint: disable=no-member
-            self.paths,
-            self.open_selected_direcotory,
-            sublime.MONOSPACE_FONT
-        )
+        elif len(self.paths) > 1:
+            self.window.show_quick_panel(
+                self.paths,
+                self.open_selected_direcotory,
+                sublime.MONOSPACE_FONT
+            )
 
     def open_selected_direcotory(self, selected_index):
         '''

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -18,10 +18,9 @@ class PathPicker(object):
     Class to manage paths for files
     '''
 
-    def __init__(self, view, selected_paths, directory_mode):
+    def __init__(self, view, selected_paths):
         self.view = view
         self.selected_paths = selected_paths
-        self.directory_mode = directory_mode
 
     def fetch_paths(self):
         """
@@ -52,8 +51,10 @@ class PathPicker(object):
         '''
         Get all root directories for project
         '''
+        settings = sublime.load_settings('termX.sublime-settings')
+        directory_mode = settings.get('directory_mode')
 
-        if self.directory_mode == 'project':
+        if directory_mode == 'project':
             return self.view.window().folders()
         else:
             if self.view.file_name() is not None:
@@ -87,15 +88,9 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         '''
 
         selected_paths = kwargs.get('paths', [])
-
-        # get settings
-        directory_mode = self.settings.get('directory_mode', 'file')
-
-        paths_picker = PathPicker(self.window.active_view(), selected_paths, directory_mode)  # pylint: disable=no-member
+        paths_picker = PathPicker(self.window.active_view(), selected_paths)  # pylint: disable=no-member
         self.paths = paths_picker.fetch_paths()
         self.open_terminal()
-
-        self.debug_info['directory_mode'] = directory_mode
         self.debug_info['paths'] = self.paths
 
         debug(self.debug_info, self.settings.get('debug', False))

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -88,7 +88,7 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         '''
 
         selected_paths = kwargs.get('paths', [])
-        paths_picker = PathPicker(self.window.active_view(), selected_paths)  # pylint: disable=no-member
+        paths_picker = PathPicker(self.window.active_view(), selected_paths)
         self.paths = paths_picker.fetch_paths()
         self.open_terminal()
         self.debug_info['paths'] = self.paths
@@ -138,14 +138,15 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
 
         # get osascript from settings or just use default value
         command.append(self.settings.get('osascript', '/usr/bin/osascript'))
-
-        if Decimal(".".join(platform.mac_ver()[0].split(".")[:2])) >= Decimal('10.10'):
+        version = '.'.join(platform.mac_ver()[0].split(".")[:2])
+        if Decimal(version) >= Decimal('10.10'):
             ext_language = 'js'
         else:
             ext_language = 'scpt'
 
         # set path and terminal
-        applescript_path = '{packages_dir}/termX/termx_{terminal_name}.{ext}'.format(
+        tpl = '{packages_dir}/termX/termx_{terminal_name}.{ext}'
+        applescript_path = tpl.format(
             packages_dir=sublime.packages_path(),
             terminal_name=self.settings.get('terminal', 'terminal'),
             ext=ext_language
@@ -155,7 +156,11 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         command.append(quoted_path)
 
         # open terminal
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=None)
+        proc = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                startupinfo=None)
         (out, err) = proc.communicate()
 
         self.debug_info['ext_language'] = ext_language

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -79,7 +79,7 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
 
         self.paths = paths
         self.debug_info['paths'] = self.paths
-        debug(self.debug_info, self.settings.get('debug', False))
+        debug(self.debug_info)
 
         if len(self.paths) == 1:
             self.open_terminal_command(self.paths[0])
@@ -137,15 +137,15 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         self.debug_info['cmd'] = ' '.join(command)
         self.debug_info['process_out'] = out
         self.debug_info['process_err'] = err
+        debug(self.debug_info)
 
 
-def debug(debug_info, debug_mode):
+def debug(debug_info):
     '''
     show some debug stuff when needed
     '''
-    if not debug_mode:
-        return False
-
-    pprint("---termX DEBUG START---")
-    pprint(debug_info)
-    pprint("---termX DEBUG END---")
+    settings = sublime.load_settings('termX.sublime-settings')
+    if settings.get('debug'):
+        pprint("---termX DEBUG START---")
+        pprint(debug_info)
+        pprint("---termX DEBUG END---")

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -93,10 +93,8 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         '''
         This method is invoked by sublime quick panel
         '''
-        if selected_index == -1:
-            return False
-
-        self.open_terminal_command(self.paths[selected_index])
+        if selected_index != -1:
+            self.open_terminal_command(self.paths[selected_index])
 
     def open_terminal_command(self, path):
         '''

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -12,6 +12,11 @@ from pprint import pprint
 from decimal import Decimal
 
 
+def get_setting(setting):
+    settings = sublime.load_settings('termX.sublime-settings')
+    return settings.get(setting)
+
+
 def get_paths_from_selection(selection):
     '''
     Get paths for selected items in sidebar.
@@ -51,7 +56,6 @@ def get_file_path(view):
 
 
 class OpenTermxTerminal(sublime_plugin.WindowCommand):
-
     '''
     Class is opening new terminal window with the path of current file
     '''
@@ -59,7 +63,6 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
     def __init__(self, *args, **kwargs):
         sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
 
-        self.settings = sublime.load_settings('termX.sublime-settings')
         self.paths = []
         self.debug_info = {}
 
@@ -105,7 +108,7 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         command = []
 
         # get osascript from settings or just use default value
-        command.append(self.settings.get('osascript', '/usr/bin/osascript'))
+        command.append(get_setting('osascript'))
         version = '.'.join(platform.mac_ver()[0].split(".")[:2])
         if Decimal(version) >= Decimal('10.10'):
             ext_language = 'js'
@@ -116,7 +119,7 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         tpl = '{packages_dir}/termX/termx_{terminal_name}.{ext}'
         applescript_path = tpl.format(
             packages_dir=sublime.packages_path(),
-            terminal_name=self.settings.get('terminal', 'terminal'),
+            terminal_name=get_setting('terminal'),
             ext=ext_language
         )
 
@@ -142,8 +145,7 @@ def debug(debug_info):
     '''
     show some debug stuff when needed
     '''
-    settings = sublime.load_settings('termX.sublime-settings')
-    if settings.get('debug'):
+    if get_setting('debug'):
         pprint("---termX DEBUG START---")
         pprint(debug_info)
         pprint("---termX DEBUG END---")

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -27,13 +27,14 @@ class PathPicker(object):
         """
         Get list of paths
         """
-        paths = self.get_paths_for_selected_items()
-        paths = self.get_project_paths(paths)
-        paths = self.get_path_for_currently_open_file(paths)
+        paths = []
+        paths += self.get_paths_from_selected_paths()
+        if not paths:
+            paths += self.get_project_paths()
 
         return list(set(paths))
 
-    def get_paths_for_selected_items(self):
+    def get_paths_from_selected_paths(self):
         '''
         Get paths for selected items in sidebar.
         '''
@@ -47,41 +48,24 @@ class PathPicker(object):
 
         return paths_to_choose
 
-    def get_project_paths(self, paths):
+    def get_project_paths(self):
         '''
-        Get all root directories for project.
+        Get all root directories for project
         '''
 
-        if len(paths) > 0:
-            return paths
-
-        if self.directory_mode != 'project':
-            return paths
-
-        paths = paths + self.view.window().folders()
-
-        return paths
-
-    def get_path_for_currently_open_file(self, paths):  # pylint: disable=invalid-name
-        '''
-        Get paths for currently open tab in sublime
-        '''
-        if len(paths) > 0:
-            return paths
-
-        if self.directory_mode != 'file':
-            return paths
-
-        if self.view.file_name() is not None:
-            paths.append(os.path.dirname(self.view.file_name()))
-
-        elif self.view.window().active_view().file_name() is not None:
-            paths.append(os.path.dirname(self.view.window().active_view().file_name()))
-
+        if self.directory_mode == 'project':
+            return self.view.window().folders()
         else:
-            paths = paths + self.view.window().folders()
-
-        return paths
+            if self.view.file_name() is not None:
+                p = []
+                p.append(os.path.dirname(self.view.file_name()))
+                return p
+            elif self.view.window().active_view().file_name() is not None:
+                p = []
+                p.append(os.path.dirname(self.view.window().active_view().file_name()))
+                return p
+            else:
+                return self.view.window().folders()
 
 
 class OpenTermxTerminal(sublime_plugin.WindowCommand):

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -86,10 +86,10 @@ class OpenTermxTerminal(sublime_plugin.WindowCommand):
         elif len(self.paths) > 1:
             self.window.show_quick_panel(
                 self.paths,
-                self.open_selected_direcotory
+                self.open_selected_directory
             )
 
-    def open_selected_direcotory(self, selected_index):
+    def open_selected_directory(self, selected_index):
         '''
         This method is invoked by sublime quick panel
         '''

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 '''
 Sublime text plugin that opens terminal.
 '''

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -57,13 +57,16 @@ class PathPicker(object):
         if directory_mode == 'project':
             return self.view.window().folders()
         else:
-            if self.view.file_name() is not None:
+            file = self.view.file_name()
+            if file is not None:
                 p = []
-                p.append(os.path.dirname(self.view.file_name()))
+                p.append(os.path.dirname(file))
                 return p
-            elif self.view.window().active_view().file_name() is not None:
+
+            file = self.view.window().active_view().file_name()
+            if file is not None:
                 p = []
-                p.append(os.path.dirname(self.view.window().active_view().file_name()))
+                p.append(os.path.dirname(file))
                 return p
             else:
                 return self.view.window().folders()

--- a/open_termx_terminal.py
+++ b/open_termx_terminal.py
@@ -85,14 +85,14 @@ class PathPicker(object):
         return paths
 
 
-class OpenTermxTerminal(sublime_plugin.TextCommand):
+class OpenTermxTerminal(sublime_plugin.WindowCommand):
 
     '''
     Class is opening new terminal window with the path of current file
     '''
 
     def __init__(self, *args, **kwargs):
-        sublime_plugin.TextCommand.__init__(self, *args, **kwargs)
+        sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
 
         self.settings = sublime.load_settings('termX.sublime-settings')
         self.paths = []
@@ -108,7 +108,7 @@ class OpenTermxTerminal(sublime_plugin.TextCommand):
         # get settings
         directory_mode = self.settings.get('directory_mode', 'file')
 
-        paths_picker = PathPicker(self.view, selected_paths, directory_mode)  # pylint: disable=no-member
+        paths_picker = PathPicker(self.window.active_view(), selected_paths, directory_mode)  # pylint: disable=no-member
         self.paths = paths_picker.fetch_paths()
         self.open_terminal()
 
@@ -135,7 +135,7 @@ class OpenTermxTerminal(sublime_plugin.TextCommand):
         Open quick selection window with paths
         '''
 
-        self.view.window().show_quick_panel(  # pylint: disable=no-member
+        self.window.show_quick_panel(  # pylint: disable=no-member
             self.paths,
             self.open_selected_direcotory,
             sublime.MONOSPACE_FONT

--- a/termX.sublime-settings
+++ b/termX.sublime-settings
@@ -10,10 +10,5 @@
     "osascript" : "/usr/bin/osascript",
 
     // Print additional info to the console for debugging problems.
-    "debug" : false,
-
-    // Where to open the new terminal. Options:
-    // - file: in the directory of the current file.
-    // - project: in the first directory open in the sidebar.
-    "directory_mode" : "file"
+    "debug" : false
 }

--- a/termX.sublime-settings
+++ b/termX.sublime-settings
@@ -1,6 +1,19 @@
 {
+	// Which application to run as your terminal. Available options:
+	// - terminal
+	// - iterm
+	// - hyper
     "terminal" : "terminal",
+
+    // The path to osascript.
+    // Run `which osascript` in a terminal to find this path on your system.
     "osascript" : "/usr/bin/osascript",
+
+    // Print additional info to the console for debugging problems.
     "debug" : false,
+
+    // Where to open the new terminal. Options:
+    // - file: in the directory of the current file.
+    // - project: in the first directory open in the sidebar.
     "directory_mode" : "file"
 }


### PR DESCRIPTION
I wanted to move away from the fixed `directory_mode` setting and instead make *where* the terminal entirely contextual. If you open the terminal via the context menu of the sidebar or the active view, that context is used to open the terminal. If you open the terminal via the command palette, there is now the option to open at the project root folder. Additionally, the command to do so can be added to the context and sidebar menus. This applies the keybinding as well, you can change the current keybinding to always open at the project folder, or add another keybinding if you want to have both options.

Additionally, to get there I updated some documentation and refactored a few things. 


---

There is more that I would like to do:

- The ability to open a terminal and run the selected file
- Remove the 1sec delay (at least in the native terminal it's not needed)
- Make opening a in new tab optional
- Make opening a new tab not rely on a specific keybinding

This would require editing the apple scripts and I wondered why both `scpt` and `js` variants exists? It's essential that both have the exact same functionality, so you'd kinda want a way to convert one to the other. I don't have a particular preference for either, except that most existing Apple Script documentation presumes `scpt`, making `js` harder to work if you don't know your way around it (which I don't, I have to look up everything here). @afterdesign any pointers here?

Anyway, consider those points as on my wish/todo list for some time in the future, it's going to be just this PR as is right now.